### PR TITLE
First version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pom.xml
 .nrepl-port
 /node_modules
 /resources
+/npm-debug.log

--- a/README.md
+++ b/README.md
@@ -1,39 +1,17 @@
 # datomish-user-agent-service
 
-FIXME: Write a one-line description of your library/project.
+```
+Usage: bin/user-agent-service [options]
 
-## Overview
-
-FIXME: Write a paragraph about the library/project and highlight its goals.
-
-## Setup
-
-To get an interactive development environment run:
-
-    lein figwheel
-
-and open your browser at [localhost:3449](http://localhost:3449/).
-This will auto compile and send all changes to the browser without the
-need to reload. After the compilation process is complete, you will
-get a Browser Connected REPL. An easy way to try it is:
-
-    (js/alert "Am I connected?")
-
-and you should see an alert in the browser window.
-
-To clean all compiled files:
-
-    lein clean
-
-To create a production build run:
-
-    lein do clean, cljsbuild once min
-
-And open your browser in `resources/public/index.html`. You will not
-get live reloading, nor a REPL. 
-
-## License
-
-Copyright © 2014 FIXME
-
-Distributed under the Eclipse Public License either version 1.0 or (at your option) any later version.
+Options:
+  -p, --port
+    The port that the UserAgentService will run on. [number] [required]
+  -d, --db
+    The path to the directory containing the browser.db. [string] [required]
+  -v, --version
+    The version of API to use. [string] [choices: "v1"] [default: "v1"]
+  -c, --content-service-origin
+    The origin of the Content Service so that CORS can be enabled. [string] [default: "tofino://"]
+  -r, --repl
+    If provided, start a REPL after launching the user agent service. [boolean]
+```

--- a/bin/user-agent-service
+++ b/bin/user-agent-service
@@ -1,0 +1,116 @@
+// TODO: License block.
+
+/* eslint-disable */
+
+var meta = {
+  "validVersions": ["v1"],
+  "defaultVersion": "v1"
+};
+
+var UserAgentService = require('../target/release-node/datomish_user_agent_service').UserAgentService;
+// var repl = require('repl');
+//var { argParser, parseArgs } = require('../../../shared/environment');
+
+var yargs = require('yargs/yargs');
+var path = require('path');
+var AppDirectory = require('appdirectory');
+var fs = require('fs-extra');
+// import manifest from '../../package.json';
+// import BUILD_CONFIG from '../build-config.json';
+
+// Electron sets a flag to let you know if the path to the app is included in
+// the command line arguments.
+const argv = process.argv.slice(process.defaultApp ? 2 : 1);
+
+const argParser = yargs(argv).usage('Usage: $0 [options]').option('P', {
+  alias: 'profile',
+  default: undefined,
+  describe: 'The user profile directory.',
+  type: 'string',
+});
+
+// let parsedArgs;
+
+// /**
+//  * Note that it is important to not call this before all of the necessary
+//  * options have been added to the above argument parser. Normally you should
+//  * add options in the top level of modules that are imported at startup then
+//  * call this some time later.
+//  */
+// export function parseArgs() {
+//   if (parsedArgs !== undefined) {
+//     return parsedArgs;
+//   }
+
+//   parsedArgs = argParser.argv;
+
+//   if (parsedArgs.profile === undefined) {
+//     if (!BUILD_CONFIG.development) {
+//       const directories = new AppDirectory({
+//         appName: manifest.name,
+//         appAuthor: manifest.author.name,
+//       });
+
+//       parsedArgs.profile = directories.userData();
+//     } else {
+//       parsedArgs.profile = path.join(LIBDIR, '..', 'profile');
+//     }
+//   }
+
+//   fs.mkdirsSync(parsedArgs.profile);
+
+//   return parsedArgs;
+// }
+
+
+// var { logger } = require('../../../shared/logging');
+
+// process.on('uncaughtException', (err) => {
+//   logger.error(err.stack);
+//   process.exit(101);
+// });
+
+// process.on('unhandledRejection', (reason, p) => {
+//   logger.error(`Unhandled Rejection at: Promise ${JSON.stringify(p)}`);
+//   logger.error(reason.stack);
+//   process.exit(102);
+// });
+
+argParser.option('p', {
+  alias: 'port',
+  require: true,
+  describe: 'The port that the UserAgentService will run on.',
+  type: 'number'
+})
+.option('v', {
+  alias: 'version',
+  describe: 'The version of API to use.',
+  choices: meta.validVersions,
+  default: meta.defaultVersion,
+  type: 'string',
+})
+.option('c', {
+  alias: 'content-service-origin',
+  describe: 'The origin of the Content Service so that CORS can be enabled.',
+  default: 'tofino://',
+  type: 'string'
+})
+.option('r', {
+  alias: 'repl',
+  require: false,
+  describe: 'If provided, start a REPL after launching the user agent service.',
+  type: 'boolean'
+});
+
+const argv2 = argParser.argv;
+
+UserAgentService({
+  port: argv2.port,
+  db: `${argv2.profile}/browser.db`,
+  version: argv2.version,
+  contentServiceOrigin: argv2.contentServiceOrigin,
+});
+
+// if (argv.repl) {
+//   repl.start();
+// }

--- a/bin/user-agent-service
+++ b/bin/user-agent-service
@@ -103,13 +103,18 @@ argParser.option('p', {
 });
 
 const argv2 = argParser.argv;
+argv2.db = `${argv2.profile}/browser-datomish.db`;
 
 UserAgentService({
   port: argv2.port,
-  db: `${argv2.profile}/browser.db`,
+  db: argv2.db,
   version: argv2.version,
   contentServiceOrigin: argv2.contentServiceOrigin,
+}).then(([start, stop]) => {
+  start();
 });
+
+console.log(`Started Datomish User Agent Service at http://127.0.0.1:${argv2.port}/${argv2.version} serving ${argv2.db}`);
 
 // if (argv.repl) {
 //   repl.start();

--- a/package.json
+++ b/package.json
@@ -7,13 +7,16 @@
   "version": "0.1.0-SNAPSHOT",
   "description": "A Tofino User Agent Service built on top of Datomish.",
   "dependencies": {
+    "appdirectory": "0.1.0",
     "body-parser": "1.15.2",
     "express": "4.14.0",
     "express-validator": "2.20.8",
+    "fs-extra": "0.30.0",
     "isomorphic-fetch": "2.2.1",
     "promise-sqlite": "1.3.0",
     "source-map-support": "ncalexan/node-source-map-support#fileUrls-plus",
-    "ws": "1.1.1"
+    "ws": "1.1.1",
+    "yargs": "5.0.0"
   },
   "repository": {
     "type": "git",
@@ -27,6 +30,7 @@
   "homepage": "https://github.com/mozilla/datomish-user-agent-service#readme",
   "main": "./target/release-node/datomish_user_agent_service.js",
   "files": [
+    "bin",
     "target/release-node/datomish_user_agent_service.js"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "datomish-user-agent-service",
-  "private": "true",
   "engines": {
     "node": "6.x.x"
   },
-  "version": "0.1.0-SNAPSHOT",
+  "version": "0.0.1",
   "description": "A Tofino User Agent Service built on top of Datomish.",
   "dependencies": {
     "appdirectory": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "body-parser": "1.15.2",
     "express": "4.14.0",
     "express-validator": "2.20.8",
+    "express-ws-routes": "1.1.0",
     "fs-extra": "0.30.0",
     "isomorphic-fetch": "2.2.1",
     "promise-sqlite": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "express-ws-routes": "1.1.0",
     "fs-extra": "0.30.0",
     "isomorphic-fetch": "2.2.1",
+    "morgan": "1.7.0",
     "promise-sqlite": "1.3.0",
     "source-map-support": "ncalexan/node-source-map-support#fileUrls-plus",
     "ws": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "url": "https://github.com/mozilla/datomish-user-agent-service/issues"
   },
   "homepage": "https://github.com/mozilla/datomish-user-agent-service#readme",
-  "main": "./app.js",
+  "main": "./target/release-node/datomish_user_agent_service.js",
   "files": [
-    "app.js"
+    "target/release-node/datomish_user_agent_service.js"
   ]
 }

--- a/release-node/test_include_node.js
+++ b/release-node/test_include_node.js
@@ -1,15 +1,29 @@
 require('source-map-support').install();
 
+process.on('uncaughtException', (err) => {
+  console.log(err.stack);
+  process.exit(101);
+});
+
+process.on('unhandledRejection', (reason, p) => {
+  console.log(`Unhandled Rejection at: Promise ${JSON.stringify(p)}`);
+  console.log(reason.stack);
+  process.exit(102);
+});
+
 var d = require('../target/release-node/datomish_user_agent_service');
 console.log("require succeeded!");
 
 d.UserAgentService({
-  port: 4000,
+  port: 9090,
   db: "",
   version: "v1",
   contentServiceOrigin: "tofino://",
-}).then((stop) => {
-  console.log("stopping");
+}).then(([start, stop]) => {
+  console.log("starting");
+  start();
+// }).then(
+//   console.log("stopping");
   // stop();
 }).then((x) => {
   console.log("stopped", x);

--- a/src/datomish_user_agent_service/api.cljc
+++ b/src/datomish_user_agent_service/api.cljc
@@ -10,6 +10,7 @@
       [cljs.core.async.macros :as a :refer [go]]))
   (:require
    [datomish.api :as d]
+   [datomish.transact] ;; Otherwise, no IConnection.close.
    [datomish.util :as util]
    #?@(:clj [
              ;; [datomish.jdbc-sqlite]
@@ -268,7 +269,7 @@
             [(get-else $ ?save :save/title "") ?title]
             [(get-else $ ?save :save/excerpt "") ?excerpt]]))
       (map (fn [[page url title excerpt]]
-             {:url url :title title :excerpt excerpt :snippet nil :lastVisited nil})))))
+             {:url url :title title :excerpt excerpt :snippet "" :lastVisited nil})))))
 
 ;; TODO: limit, since.
 ;; TODO: return lastVisited, sort by lastVisited.
@@ -287,7 +288,7 @@
                    '[(get-else $ ?save :save/title "") ?title]
                    '[(get-else $ ?save :save/excerpt "") ?excerpt]]}))
       (map (fn [[page url title excerpt]]
-             {:url url :title title :excerpt excerpt :snippet nil :lastVisited nil})))))
+             {:url url :title title :excerpt excerpt :snippet "" :lastVisited nil})))))
 
 ;; TODO: return ID?
 (defn <add-visit [conn {:keys [url uri title session]}]
@@ -335,7 +336,7 @@
                         :order-by [[:_max_time :desc]]
                         :inputs {:since since}}))]
         (map (fn [[url title lastVisited]]
-               {:url url :title title :lastVisited lastVisited})
+               {:url url :title title :lastVisited lastVisited :snippet ""})
              rows)))))
 
 (defn <find-title [db url]

--- a/src/datomish_user_agent_service/api.cljc
+++ b/src/datomish_user_agent_service/api.cljc
@@ -39,6 +39,7 @@
   [{:db/id (d/id-literal :db.part/user)
     :db/ident              :page/url
     :db/valueType          :db.type/string          ; Because not all URLs are java.net.URIs. For JS we may want to use /uri.
+    :db/fulltext           true
     :db/cardinality        :db.cardinality/one
     :db/unique             :db.unique/identity
     :db/doc                "A page's URL."
@@ -46,6 +47,7 @@
    {:db/id (d/id-literal :db.part/user)
     :db/ident              :page/title
     :db/valueType          :db.type/string
+    :db/fulltext           true
     :db/cardinality        :db.cardinality/one      ; We supersede as we see new titles.
     :db/doc                "A page's title."
     :db.install/_attribute :db.part/db}

--- a/src/datomish_user_agent_service/core.cljs
+++ b/src/datomish_user_agent_service/core.cljs
@@ -26,7 +26,6 @@
 ;; We want to refer to app by name; partial captures the value at
 ;; definition time.
 (defn- handle [& rest]
-  (println "handler" app rest)
   (apply app rest))
 
 (defn -main []

--- a/src/datomish_user_agent_service/core.cljs
+++ b/src/datomish_user_agent_service/core.cljs
@@ -39,12 +39,7 @@
                                          (js/process.exit 102)))
 
   (a/take!
-    (go-pair
-      (js/console.log "Opening Datomish knowledge-base.")
-      (let [c (<? (d/<connect "")) ;; In-memory for now.
-            _ (<? (d/<transact! c api/tofino-schema))
-            ]
-        c))
+    (server/<connect "") ;; In-memory for now.
     (partial a/offer! connection-pair-chan))
 
   (let [[start stop] (server/createServer handle {:port 9090})]

--- a/src/datomish_user_agent_service/externs/datomish_user_agent_service.js
+++ b/src/datomish_user_agent_service/externs/datomish_user_agent_service.js
@@ -155,6 +155,7 @@ express.Router.prototype.ws = function(path, func) {};
 express.Router.prototype.websocket = function(path, func) {};
 express.Router.prototype.on = function(event, func) {};
 
+express.request.prototype.get = function(key) {};
 express.request.prototype.checkBody = function(value) {};
 express.request.prototype.checkQuery = function(value) {};
 express.request.prototype.optional = function(value) {};
@@ -165,6 +166,7 @@ express.request.prototype.validationErrors = function(value) {};
 express.response.prototype.status = function(value) {};
 express.response.prototype.send = function(value) {};
 express.response.prototype.json = function(value) {};
+express.response.prototype.header = function(key, value) {};
 
 function morgan(style) {};
 

--- a/src/datomish_user_agent_service/externs/datomish_user_agent_service.js
+++ b/src/datomish_user_agent_service/externs/datomish_user_agent_service.js
@@ -155,6 +155,8 @@ express.Router.prototype.ws = function(path, func) {};
 express.Router.prototype.websocket = function(path, func) {};
 express.Router.prototype.on = function(event, func) {};
 
+express.request.prototype.accepts = function(mimeType) {};
+express.request.prototype.is = function(mimeType) {};
 express.request.prototype.get = function(key) {};
 express.request.prototype.checkBody = function(value) {};
 express.request.prototype.checkQuery = function(value) {};
@@ -164,11 +166,19 @@ express.request.prototype.isInt = function(value) {};
 express.request.prototype.validationErrors = function(value) {};
 
 express.response.prototype.status = function(value) {};
+express.response.prototype.set = function(value) {};
 express.response.prototype.send = function(value) {};
 express.response.prototype.json = function(value) {};
 express.response.prototype.header = function(key, value) {};
 
+express.static = function(path) {};
+
 function morgan(style) {};
+
+var bodyParser;
+bodyParser.prototype.json = function(options) {};
+bodyParser.prototype.text = function(options) {};
+bodyParser.prototype.urlencoded = function(options) {};
 
 var http = {};
 

--- a/src/datomish_user_agent_service/externs/datomish_user_agent_service.js
+++ b/src/datomish_user_agent_service/externs/datomish_user_agent_service.js
@@ -147,6 +147,14 @@ express.Router.prototype.post = function(path, func) {};
  */
 express.Router.prototype.delete = function(path, func) {};
 
+var expressWs;
+expressWs.extendExpress = function() {};
+expressWs.createWebSocketServer = function(module, server, handler) {};
+
+express.Router.prototype.ws = function(path, func) {};
+express.Router.prototype.websocket = function(path, func) {};
+express.Router.prototype.on = function(event, func) {};
+
 express.request.prototype.checkBody = function(value) {};
 express.request.prototype.checkQuery = function(value) {};
 express.request.prototype.optional = function(value) {};
@@ -157,6 +165,8 @@ express.request.prototype.validationErrors = function(value) {};
 express.response.prototype.status = function(value) {};
 express.response.prototype.send = function(value) {};
 express.response.prototype.json = function(value) {};
+
+function morgan(style) {};
 
 var http = {};
 

--- a/src/datomish_user_agent_service/js.cljs
+++ b/src/datomish_user_agent_service/js.cljs
@@ -39,7 +39,7 @@
         (throw (js/Error. "UserAgentService requires a `contentServiceOrigin` string.")))
 
       (let [{:keys [port db version contentServiceOrigin]} options]
-        (js/console.log "Opening Datomish knowledge-base at" (:db options))
+        (println "Opening Datomish knowledge-base at" (:db options))
 
         (let [c (go-pair ;; Blocked on (repeatedly!) in server/app.  This is just one way to async sequence.
                   (let [c (<? (d/<connect db)) ;; In-memory for now.
@@ -59,7 +59,7 @@
                 (go-promise
                   identity
 
-                  (<? (d/<close c))
+                  (<? (d/<close (<? c)))
 
                   ;; A promise that returns a promise.
                   (promise (fn [resolve reject]
@@ -72,3 +72,5 @@
 
 (defn -main [])
 (set! *main-cli-fn* -main)
+
+(aset js/module "exports" #js {:UserAgentService UserAgentService})

--- a/src/datomish_user_agent_service/server.cljs
+++ b/src/datomish_user_agent_service/server.cljs
@@ -22,6 +22,7 @@
 ;; Monkeypatch!
 (.extendExpress expressWs #js {})
 (defonce bodyParser (nodejs/require "body-parser"))
+(defonce morgan (nodejs/require "morgan"))
 
 ;; TODO: validate in CLJS.
 (defn- auto-caught-route-error [validator method]
@@ -298,10 +299,6 @@
           (.header "Access-Control-Allow-Headers" "Content-Type")))
       (next))))
 
-(defn- log-handler [req res next]
-  (println "req" req)
-  (next))
-
 (defn- error-handler [err req res next]
   (doto res
     (.status 500)
@@ -319,7 +316,8 @@
 
         app
         (doto (express)
-          (.use log-handler)
+          (.use (morgan "dev"))
+
           (.use (cross-origin-handler "tofino://")) ;; TODO: parameterize origin.
 
           (.use (.json bodyParser))

--- a/src/datomish_user_agent_service/server.cljs
+++ b/src/datomish_user_agent_service/server.cljs
@@ -1,35 +1,45 @@
 (ns ^:figwheel-always datomish-user-agent-service.server
   (:require-macros
    [datomish.pair-chan :refer [go-pair <?]]
+   [datomish.promises :refer [go-promise]]
    [cljs.core.async.macros :refer [go]])
   (:require [cljs.nodejs :as nodejs]
+            [cljs-promises.async]
+            [cljs-promises.core :refer [promise]]
             [datomish.api :as d]
             [datomish.js-sqlite] ;; Otherwise, we won't have the ISQLiteConnectionFactory defns.
             [datomish.pair-chan]
+            [datomish.promises]
             [datomish-user-agent-service.api :as api]
             [cljs.core.async :as a :refer [chan <! >!]]))
 
+(.install (nodejs/require "source-map-support"))
 
+(defonce http (nodejs/require "http"))
 (defonce express (nodejs/require "express"))
 (defonce expressValidator (nodejs/require "express-validator"))
+(defonce expressWs (nodejs/require "express-ws-routes"))
+;; Monkeypatch!
+(.extendExpress expressWs #js {})
 (defonce bodyParser (nodejs/require "body-parser"))
 
 ;; TODO: validate in CLJS.
 (defn- auto-caught-route-error [validator method]
   (fn [req res next]
-    (go-pair
+    (go-promise
+      identity
+
       (try
         (when validator
           (validator req))
         (let [errors (.validationErrors req)]
           (if errors
-            ;; TODO: log.
             (doto res
               (.status 401)
               (.json (clj->js errors)))
             ;; TODO: .catch errors in method?
             (<? (method req res next))))
-        (catch js/Error e
+        (catch :default e
           (js/console.log "caught error" e)
           (doto res
             (.status 500)
@@ -37,193 +47,244 @@
           )))))
 
 (defn- router [connection-pair-chan]
-  (doto (-> express .Router)
+  (let [ws-clients
+        (atom #{})
 
-    ;; TODO: write a small macro to cut down this boilerplate.
-    (.post "/sessions/start"
-           (auto-caught-route-error
-             (fn [req]
-               (-> req
-                   (.checkBody "scope")
-                   (.optional)
-                   (.isInt))
-               (-> req
-                   (.checkBody "ancestor")
-                   (.optional)
-                   (.isInt))
-               )
-             (fn [req res]
-               (go-pair
-                 (let [session (<? (api/<start-session (<? connection-pair-chan)
-                                                       {:ancestor (aget req "body" "ancestor")
-                                                        :scope (aget req "body" "scope")}))]
-                   (.json res (clj->js {:session session})))))))
+        diff
+        (fn [type payload]
+          (println "Sending diff message of type" type "and payload" payload "to" (count @ws-clients) "clients")
+          (let [message (js/JSON.stringify (clj->js {:message "diff" :type type :payload payload}))]
+            (go-pair
+              (doseq [ws @ws-clients]
+                (.send ws message)))))
 
-    (.post "/sessions/end"
-           (auto-caught-route-error
-             (fn [req]
-               (-> req
-                   (.checkBody "session")
-                   (.notEmpty)
-                   (.isInt))
-               )
-             (fn [req res]
-               (go-pair
-                 (let [_ (<? (api/<end-session (<? connection-pair-chan)
-                                               {:session (aget req "body" "session")}))]
-                   (.json res (clj->js {})))))))
+        send-bookmark-diffs
+        (fn []
+          (go-promise
+            identity
 
-    (.post "/visits/visit"
-           (auto-caught-route-error
-             (fn [req]
-               (-> req
-                   (.checkBody "url")
-                   (.notEmpty))
-               (-> req
-                   (.checkBody "title")
-                   (.optional))
-               (-> req
-                   (.checkBody "session")
-                   (.notEmpty)
-                   (.isInt))
-               )
-             (fn [req res]
-               (go-pair
-                 (let [_ (<? (api/<add-visit (<? connection-pair-chan)
-                                             {:url (aget req "body" "url")
-                                              :title (aget req "body" "title")
-                                              :session (aget req "body" "session")}))]
-                   (.json res (clj->js {})))))))
+            (let [results (<? (api/<starred-pages (d/db (<? connection-pair-chan)) ;; TODO -- unify on conn over db?
+                                                  {:limit 100} ;; TODO - js/Number.MAX_SAFE_INTEGER
+                                                  ))]
+              (<? (diff "PROFILE_DIFF_BOOKMARKS" (map :url results)))
+              (<? (diff "PROFILE_DIFF_RECENT_BOOKMARKS" (map :url results))))))
+        ]
 
-    (.get "/visits"
-          (auto-caught-route-error
-            (fn [req]
-              (-> req
-                  (.checkQuery "limit")
-                  (.optional)
-                  (.isInt))
-              )
-            (fn [req res]
-              (go-pair
-                (let [results (<? (api/<visited (d/db (<? connection-pair-chan)) ;; TODO -- unify on conn over db?
-                                                {:limit (int (aget req "query" "limit"))}))]
-                  (.json res (clj->js {:results results})))))))
+    (doto (-> express .Router)
 
-    (.post "/stars/star"
-           (auto-caught-route-error
-             (fn [req]
-               (-> req
-                   (.checkBody "url")
-                   (.notEmpty))
-               (-> req
-                   (.checkBody "title")
-                   (.optional))
-               (-> req
-                   (.checkBody "session")
-                   (.notEmpty)
-                   (.isInt))
-               )
-             (fn [req res]
-               (go-pair
-                 (let [_ (<? (api/<star-page (<? connection-pair-chan)
-                                             {:url (aget req "body" "url")
-                                              :title (aget req "body" "title") ;; TODO: allow no title.
-                                              :starred true
-                                              :session (int (aget req "body" "session"))}))]
-                   ;; TODO: dispatch bookmark diffs to WS.
-                   (.json res (clj->js {})))))))
+      (.websocket "/ws" (fn [info cb next]
+                          (cb (fn [ws]
+                                (go-promise
+                                  identity
 
-    (.post "/stars/unstar"
-           (auto-caught-route-error
-             (fn [req]
-               (-> req
-                   (.checkBody "url")
-                   (.notEmpty))
-               (-> req
-                   (.checkBody "session")
-                   (.notEmpty)
-                   (.isInt))
-               )
-             (fn [req res]
-               (go-pair
-                 (let [_ (<? (api/<star-page (<? connection-pair-chan)
-                                             {:url (aget req "body" "url")
-                                              :starred false
-                                              :session (int (aget req "body" "session"))}))]
-                   ;; TODO: dispatch bookmark diffs to WS.
-                   (.json res (clj->js {})))))))
+                                  (swap! ws-clients conj ws)
+                                  (.on ws "close" (fn [] (swap! ws-clients disj ws)))
 
-    (.get "/stars"
-          (auto-caught-route-error
-            (fn [req]
-              (-> req
-                  (.checkQuery "limit")
-                  (.optional)
-                  (.isInt))
-              )
-            (fn [req res]
-              (go-pair
-                (let [results (<? (api/<starred-pages (d/db (<? connection-pair-chan)) ;; TODO -- unify on conn over db?
-                                                      {:limit (int (or (aget req "query" "limit") 100))} ;; TODO - js/Number.MAX_SAFE_INTEGER
-                                                      ))]
-                  (.json res (clj->js {:results results})))))))
+                                  (.send ws (js/JSON.stringify #js {:message "protocol"
+                                                                    :version "v1"
+                                                                    :clientCount (count @ws-clients)}))
+                                  (.send ws (js/JSON.stringify #js {:type "connected"}))
 
-    (.post "/pages/page"
-           (auto-caught-route-error
-             (fn [req]
-               (-> req
-                   (.checkBody "url")
-                   (.notEmpty))
-               (-> req
-                   (.checkBody #js ["page" "textContent"]) ;; #js is required here and below.
-                   (.notEmpty))
-               (-> req
-                   (.checkBody #js ["page" "title"])
-                   (.optional))
-               (-> req
-                   (.checkBody #js ["page" "excerpt"])
-                   (.optional))
-               (-> req
-                   (.checkBody "session")
-                   (.notEmpty)
-                   (.isInt))
-               )
-             (fn [req res]
-               (go-pair
-                 (let [_ (<? (api/<save-page (<? connection-pair-chan)
-                                             {:url (aget req "body" "url")
-                                              :title (aget req "body" "page" "title")
-                                              :excerpt (aget req "body" "page" "excerpt")
-                                              :content (aget req "body" "page" "textContent")
-                                              :session (int (aget req "body" "session"))}))]
-                   ;; TODO: dispatch bookmark diffs to WS.
-                   (.json res (clj->js {})))))))
+                                  ;; Asynchronously send bookmark diffs.
+                                  (send-bookmark-diffs)
 
-    (.get "/pages"
-          (auto-caught-route-error
-            (fn [req]
-              (-> req
-                  (.checkQuery "q")
-                  (.notEmpty))
-              (-> req
-                  (.checkQuery "limit")
-                  (.optional)
-                  (.isInt))
-              (-> req
-                  (.checkQuery "since")
-                  (.optional)
-                  (.isInt))
-              (-> req
-                  (.checkQuery "snippetSize")
-                  (.optional))
-              )
-            (fn [req res]
-              (go-pair
-                (let [results (<? (api/<saved-pages-matching-string (d/db (<? connection-pair-chan)) ;; TODO -- unify on conn over db?
-                                                                    (aget req "query" "q")
-                                                                    ;; {:limit (int (or (-> req .-query .-limit) 100))} ;; TODO - js/Number.MAX_SAFE_INTEGER
-                                                                    ))]
-                  (.json res (clj->js {:results results})))))))))
+                                  )))))
+
+
+      ;; TODO: write a small macro to cut down this boilerplate.
+      (.post "/sessions/start"
+             (auto-caught-route-error
+               (fn [req]
+                 (-> req
+                     (.checkBody "scope")
+                     (.optional)
+                     (.isInt))
+                 (-> req
+                     (.checkBody "ancestor")
+                     (.optional)
+                     (.isInt))
+                 )
+               (fn [req res]
+                 (go-pair
+                   (let [session (<? (api/<start-session (<? connection-pair-chan)
+                                                         {:ancestor (aget req "body" "ancestor")
+                                                          :scope (aget req "body" "scope")}))]
+                     (.json res (clj->js {:session session})))))))
+
+      (.post "/sessions/end"
+             (auto-caught-route-error
+               (fn [req]
+                 (-> req
+                     (.checkBody "session")
+                     (.notEmpty)
+                     (.isInt))
+                 )
+               (fn [req res]
+                 (go-pair
+                   (let [_ (<? (api/<end-session (<? connection-pair-chan)
+                                                 {:session (aget req "body" "session")}))]
+                     (.json res (clj->js {})))))))
+
+      (.post "/visits/visit"
+             (auto-caught-route-error
+               (fn [req]
+                 (-> req
+                     (.checkBody "url")
+                     (.notEmpty))
+                 (-> req
+                     (.checkBody "title")
+                     (.optional))
+                 (-> req
+                     (.checkBody "session")
+                     (.notEmpty)
+                     (.isInt))
+                 )
+               (fn [req res]
+                 (go-pair
+                   (let [_ (<? (api/<add-visit (<? connection-pair-chan)
+                                               {:url (aget req "body" "url")
+                                                :title (aget req "body" "title")
+                                                :session (aget req "body" "session")}))]
+                     (.json res (clj->js {})))))))
+
+      (.get "/visits"
+            (auto-caught-route-error
+              (fn [req]
+                (-> req
+                    (.checkQuery "limit")
+                    (.optional)
+                    (.isInt))
+                )
+              (fn [req res]
+                (go-pair
+                  (let [results (<? (api/<visited (d/db (<? connection-pair-chan)) ;; TODO -- unify on conn over db?
+                                                  {:limit (int (aget req "query" "limit"))}))]
+                    (.json res (clj->js {:results results})))))))
+
+      (.post "/stars/star"
+             (auto-caught-route-error
+               (fn [req]
+                 (-> req
+                     (.checkBody "url")
+                     (.notEmpty))
+                 (-> req
+                     (.checkBody "title")
+                     (.optional))
+                 (-> req
+                     (.checkBody "session")
+                     (.notEmpty)
+                     (.isInt))
+                 )
+               (fn [req res]
+                 (go-pair
+                   (let [_ (<? (api/<star-page (<? connection-pair-chan)
+                                               {:url (aget req "body" "url")
+                                                :title (aget req "body" "title") ;; TODO: allow no title.
+                                                :starred true
+                                                :session (int (aget req "body" "session"))}))]
+
+                     ;; Asynchronously send bookmark diffs.
+                     (send-bookmark-diffs)
+
+                     (.json res (clj->js {})))))))
+
+      (.post "/stars/unstar"
+             (auto-caught-route-error
+               (fn [req]
+                 (-> req
+                     (.checkBody "url")
+                     (.notEmpty))
+                 (-> req
+                     (.checkBody "session")
+                     (.notEmpty)
+                     (.isInt))
+                 )
+               (fn [req res]
+                 (go-pair
+                   (let [_ (<? (api/<star-page (<? connection-pair-chan)
+                                               {:url (aget req "body" "url")
+                                                :starred false
+                                                :session (int (aget req "body" "session"))}))]
+
+                     ;; Asynchronously send bookmark diffs.
+                     (send-bookmark-diffs)
+
+                     (.json res (clj->js {})))))))
+
+      (.get "/stars"
+            (auto-caught-route-error
+              (fn [req]
+                (-> req
+                    (.checkQuery "limit")
+                    (.optional)
+                    (.isInt))
+                )
+              (fn [req res]
+                (go-pair
+                  (let [results (<? (api/<starred-pages (d/db (<? connection-pair-chan)) ;; TODO -- unify on conn over db?
+                                                        {:limit (int (or (aget req "query" "limit") 100))} ;; TODO - js/Number.MAX_SAFE_INTEGER
+                                                        ))]
+                    (.json res (clj->js {:results results})))))))
+
+      (.post "/pages/page"
+             (auto-caught-route-error
+               (fn [req]
+                 (-> req
+                     (.checkBody "url")
+                     (.notEmpty))
+                 (-> req
+                     (.checkBody #js ["page" "textContent"]) ;; #js is required here and below.
+                     (.notEmpty))
+                 (-> req
+                     (.checkBody #js ["page" "title"])
+                     (.optional))
+                 (-> req
+                     (.checkBody #js ["page" "excerpt"])
+                     (.optional))
+                 (-> req
+                     (.checkBody "session")
+                     (.notEmpty)
+                     (.isInt))
+                 )
+               (fn [req res]
+                 (go-pair
+                   (let [_ (<? (api/<save-page (<? connection-pair-chan)
+                                               {:url (aget req "body" "url")
+                                                :title (aget req "body" "page" "title")
+                                                :excerpt (aget req "body" "page" "excerpt")
+                                                :content (aget req "body" "page" "textContent")
+                                                :session (int (aget req "body" "session"))}))]
+                     (.json res (clj->js {})))))))
+
+      (.get "/pages"
+            (auto-caught-route-error
+              (fn [req]
+                (-> req
+                    (.checkQuery "q")
+                    (.notEmpty))
+                (-> req
+                    (.checkQuery "limit")
+                    (.optional)
+                    (.isInt))
+                (-> req
+                    (.checkQuery "since")
+                    (.optional)
+                    (.isInt))
+                (-> req
+                    (.checkQuery "snippetSize")
+                    (.optional))
+                )
+              (fn [req res]
+                (go-pair
+                  (let [results (<? (api/<saved-pages-matching-string (d/db (<? connection-pair-chan)) ;; TODO -- unify on conn over db?
+                                                                      (aget req "query" "q")
+                                                                      ;; {:limit (int (or (-> req .-query .-limit) 100))} ;; TODO - js/Number.MAX_SAFE_INTEGER
+                                                                      ))]
+                    (.json res (clj->js {:results results}))))))))))
+
+(defn- log-handler [req res next]
+  (println "req" req)
+  (next))
 
 (defn- error-handler [err req res next]
   (doto res
@@ -237,13 +298,43 @@
 
 ;; TODO: logging throughout.
 (defn app [connection-pair-chan]
-  (doto (express)
-    (.use (.json bodyParser))
-    (.use (expressValidator))
-    (.use "/v1" (router connection-pair-chan))
+  (let [router
+        (router connection-pair-chan)
 
-    (.get "/__heartbeat__" 
-          (fn [req res] (.json res (clj->js {:version "v1"}))))
+        app
+        (doto (express)
+          (.use log-handler)
 
-    (.use not-found-handler)
-    (.use error-handler)))
+          (.use (.json bodyParser))
+          (.use (expressValidator))
+          (.use "/v1" router)
+
+          (.get "/__heartbeat__"
+                (fn [req res] (.json res (clj->js {:version "v1"}))))
+
+          (.use not-found-handler)
+          (.use error-handler))]
+    app))
+
+(defn createServer [request-listener {:keys [port]
+                                      :or {port 9090}}]
+  (let [server
+        (.createServer http request-listener)
+
+        ;; There's magic around `handle` here: this is arranging to not need to capture the Express
+        ;; Application directly; handle is an internal detail of express-ws-routes.
+        _
+        (aset server "wsServer" (.createWebSocketServer expressWs server #js {:handle request-listener}))
+
+        start
+        (fn []
+          (promise (fn [resolve reject]
+                     (.listen server port resolve))))
+
+        stop
+        (fn []
+          (promise (fn [resolve reject]
+                     (.close server (fn [err] (if err
+                                                (reject err)
+                                                (resolve)))))))]
+    [start stop server]))

--- a/src/datomish_user_agent_service/server.cljs
+++ b/src/datomish_user_agent_service/server.cljs
@@ -40,7 +40,7 @@
   (doto (-> express .Router)
 
     ;; TODO: write a small macro to cut down this boilerplate.
-    (.post "/session/start"
+    (.post "/sessions/start"
            (auto-caught-route-error
              (fn [req]
                (-> req
@@ -59,7 +59,7 @@
                                                         :scope (aget req "body" "scope")}))]
                    (.json res (clj->js {:session session})))))))
 
-    (.post "/session/end"
+    (.post "/sessions/end"
            (auto-caught-route-error
              (fn [req]
                (-> req
@@ -73,7 +73,7 @@
                                                {:session (aget req "body" "session")}))]
                    (.json res (clj->js {})))))))
 
-    (.post "/visits"
+    (.post "/visits/visit"
            (auto-caught-route-error
              (fn [req]
                (-> req
@@ -107,7 +107,7 @@
               (go-pair
                 (let [results (<? (api/<visited (d/db (<? connection-pair-chan)) ;; TODO -- unify on conn over db?
                                                 {:limit (int (aget req "query" "limit"))}))]
-                  (.json res (clj->js {:pages results})))))))
+                  (.json res (clj->js {:results results})))))))
 
     (.post "/stars/star"
            (auto-caught-route-error
@@ -168,7 +168,7 @@
                                                       ))]
                   (.json res (clj->js {:results results})))))))
 
-    (.post "/pages"
+    (.post "/pages/page"
            (auto-caught-route-error
              (fn [req]
                (-> req
@@ -199,7 +199,7 @@
                    ;; TODO: dispatch bookmark diffs to WS.
                    (.json res (clj->js {})))))))
 
-    (.get "/query"
+    (.get "/pages"
           (auto-caught-route-error
             (fn [req]
               (-> req

--- a/src/datomish_user_agent_service/server.cljs
+++ b/src/datomish_user_agent_service/server.cljs
@@ -353,3 +353,13 @@
                                                 (reject err)
                                                 (resolve)))))))]
     [start stop server]))
+
+(defn <connect [path]
+  ;; Using pair-port and go-promise works around issues seen using a promise-chan in this way.
+  (cljs-promises.async/pair-port
+    (go-promise
+      identity
+
+      (let [c (<? (d/<connect path))
+            _ (<? (d/<transact! c api/tofino-schema))] ;; TODO: don't do try to write.
+        c))))

--- a/test/datomish_user_agent_service/core_test.cljs
+++ b/test/datomish_user_agent_service/core_test.cljs
@@ -72,32 +72,32 @@
 (deftest-async test-session
   (let [server (core/server 3002)]
     (try
-      (let [{s1 :session} (<? (<post "http://localhost:3002/v1/session/start" {}))
-            {s2 :session} (<? (<post "http://localhost:3002/v1/session/start" {:scope s1}))]
+      (let [{s1 :session} (<? (<post "http://localhost:3002/v1/sessions/start" {}))
+            {s2 :session} (<? (<post "http://localhost:3002/v1/sessions/start" {:scope s1}))]
         (is (number? s1))
         (is (number? s2))
         (is (= s1 (dec s2)))
 
-        (is (= (<? (<post "http://localhost:3002/v1/session/end" {:session s1})) {}))
-        (is (= (<? (<post "http://localhost:3002/v1/session/end" {:session s2})) {}))
+        (is (= (<? (<post "http://localhost:3002/v1/sessions/end" {:session s1})) {}))
+        (is (= (<? (<post "http://localhost:3002/v1/sessions/end" {:session s2})) {}))
 
         ;; TODO: 404 the second time through.
-        (is (= (<? (<post "http://localhost:3002/v1/session/end" {:session s1})) {})))
+        (is (= (<? (<post "http://localhost:3002/v1/sessions/end" {:session s1})) {})))
 
       (finally (.close server)))))
 
 (deftest-async test-visits
   (let [server (core/server 3002)]
     (try
-      (let [{s :session} (<? (<post "http://localhost:3002/v1/session/start" {}))]
+      (let [{s :session} (<? (<post "http://localhost:3002/v1/sessions/start" {}))]
         ;; No title.
-        (is (= (<? (<post "http://localhost:3002/v1/visits" {:session s
-                                                             :url "https://reddit.com/"}))
+        (is (= (<? (<post "http://localhost:3002/v1/visits/visit" {:session s
+                                                                   :url "https://reddit.com/"}))
                {}))
         ;; With title.
-        (is (= (<? (<post "http://localhost:3002/v1/visits" {:session s
-                                                             :url "https://www.mozilla.org/en-US/firefox/new/"
-                                                             :title "Download Firefox - Free Web Browser"}))
+        (is (= (<? (<post "http://localhost:3002/v1/visits/visit" {:session s
+                                                                   :url "https://www.mozilla.org/en-US/firefox/new/"
+                                                                   :title "Download Firefox - Free Web Browser"}))
                {}))
         ;; TODO: 400 with no URL or no session (or invalid URL?).
 
@@ -115,7 +115,7 @@
 (deftest-async test-stars
   (let [server (core/server 3002)]
     (try
-      (let [{s :session} (<? (<post "http://localhost:3002/v1/session/start" {}))]
+      (let [{s :session} (<? (<post "http://localhost:3002/v1/sessions/start" {}))]
         ;; TODO: Allow no title.
         (is (= (<? (<post "http://localhost:3002/v1/stars/star"
                           {:url "https://reddit.com/"
@@ -158,7 +158,7 @@
 (deftest-async test-page-details
   (let [server (core/server 3002)]
     (try
-      (let [{s :session} (<? (<post "http://localhost:3002/v1/session/start" {}))]
+      (let [{s :session} (<? (<post "http://localhost:3002/v1/sessions/start" {}))]
         (is (= (<? (<post "http://localhost:3002/v1/pages"
                           {:session s
                            :url "https://test.domain/"


### PR DESCRIPTION
@rnewman this tree is a bit of a mess, so you might just want to look at the final diff.  Totally your call.  Might as well get something landed and polish from there.

After applying https://github.com/mozilla/tofino/pull/1262, Tofino runs locally against this.

For testing against Tofino, modify the Tofino `app/packages.json` to point at your local package directory and run `lein cljsbuild auto release-node`.  That'll update the `target/release-node/datomish-user-agent-service.js` in place, which will get picked up by the bin script used by Tofino.  It works pretty well.

For testing with cURL, run `lein figwheel dev` in one terminal, and then `node target/release-node/datomish_user_agent_service.js` in another terminal.  That'll hot reload the server code, taking care to maintain the same HTTP server while swapping out the Express router.  (With a little work we'll be able to preserve the WS clients across swaps too.)

For running the (minimal) tests, `lein doo node test` hot reloads the tests.

There's lots of work to be done, including getting those instructions into the README; I'll file a roadmap issue to dump some of those issues when I get energy.  Onwards!